### PR TITLE
Add Goose MCP client

### DIFF
--- a/cmd/docker-mcp/client/config.yml
+++ b/cmd/docker-mcp/client/config.yml
@@ -69,6 +69,20 @@ system:
       list: '.mcpServers | to_entries | map(.value + {"name": .key})'
       set: .mcpServers[$NAME] = $JSON+{"transport":"stdio"}
       del: del(.mcpServers[$NAME])
+  goose:
+    displayName: Goose
+    source: https://block.github.io/goose/
+    installCheckPaths:
+    - $HOME/.config/goose
+    - $APPDATA\Block\goose\config
+    paths:
+      linux: $HOME/.config/goose/config.yaml
+      darwin: $HOME/.config/goose/config.yaml
+      windows: $APPDATA\Block\goose\config\config.yaml
+    yq:
+      list: '.extensions | to_entries | map(.value + {"name": .key})'
+      set: .extensions[$NAME] = $JSON
+      del: del(.extensions[$NAME])
 project:
   cursor:
     displayname: Cursor


### PR DESCRIPTION
## Summary
- add Goose to supported MCP clients

## Testing
- `make lint` *(fails: `docker` not found)*
- `make test` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68755ec727b48320a48c2cd73e6bcd9e